### PR TITLE
Target .NET Standard & update README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,53 +33,33 @@ Install-Package VRChat.API -Version <LATEST_VERSION>
 The following example code authenticates you with the API, fetches your join-date, and prints the name of a world.
 
 ```csharp
-using System;
-using System.Diagnostics;
-using System.Threading.Tasks;
 using VRChat.API.Api;
 using VRChat.API.Client;
 using VRChat.API.Model;
 
-namespace Example
+Configuration config = new Configuration();
+config.Username = "username";
+config.Password = "password";
+
+try
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            MainAsync().Wait();
-            Console.ReadKey();
-        }
+    AuthenticationApi authApi = new AuthenticationApi(config);
+    var user = await authApi.GetCurrentUserAsync();
+    Console.WriteLine("Logged in as {0}, Current Avatar {1}", user.DisplayName, user.CurrentAvatar);
 
-        static async Task MainAsync()
-        {
-            // Configure API login credentials
-            Configuration config = new Configuration();
-            config.Username = "username";
-            config.Password = "password";
+    UsersApi userApi = new UsersApi(config);
+    var user = await userApi.GetUserAsync(user.Id);
+    Console.WriteLine("Found user {0}, joined {1}", user.DisplayName, user.DateJoined);
 
-            try
-            {
-                // Calling "GetCurrentUser" will log you in.
-                AuthenticationApi authApi = new AuthenticationApi(config);
-                var user = await authApi.GetCurrentUserAsync();
-                Console.WriteLine($"Logged in user {user.DisplayName}, Current Avatar {user.CurrentAvatar}");
-
-                UsersApi userApi = new UsersApi(config);
-                var getUser = await userApi.GetUserAsync(user.Id);
-                Console.WriteLine($"Found user {getUser.DisplayName}, joined {getUser.DateJoined}");
-
-                WorldsApi worldApi = new WorldsApi(config);
-                var world = await worldApi.GetWorldAsync("wrld_ba913a96-fac4-4048-a062-9aa5db092812");
-                Console.WriteLine($"Found world {world.Name}, visits: {world.Visits}");
-            }
-            catch (ApiException e)
-            {
-                Debug.Print("Exception when calling API: " + e.Message);
-                Debug.Print("Status Code: " + e.ErrorCode);
-                Debug.Print(e.StackTrace);
-            }
-        }
-    }
+    WorldsApi worldApi = new WorldsApi(config);
+    var world = await worldApi.GetWorldAsync("wrld_ba913a96-fac4-4048-a062-9aa5db092812");
+    Console.WriteLine("Found world {0}, visits: {1}", world.Name, world.Visits);
+}
+catch (ApiException e)
+{
+    Console.WriteLine("Exception when calling API: {0}", e.Message);
+    Console.WriteLine("Status Code: {0}", e.ErrorCode);
+    Console.WriteLine(e.ToString());
 }
 ```
 

--- a/generate.sh
+++ b/generate.sh
@@ -10,7 +10,7 @@ SPEC_VERSION=`grep "^  version:" openapi.yaml | cut -d " " -f 4`
 
 ./node_modules/\@openapitools/openapi-generator-cli/main.js generate \
 -g csharp-netcore \
---additional-properties=packageName=VRChat.API,packageTags=vrchat,packageVersion=$SPEC_VERSION,targetFramework=net5.0,licenseId=MIT \
+--additional-properties=packageName=VRChat.API,packageTags=vrchat,packageVersion=$SPEC_VERSION,targetFramework=netstandard2.0,licenseId=MIT \
 --git-user-id=vrchatapi \
 --git-repo-id=vrchatapi-csharp \
 -o . \
@@ -26,8 +26,8 @@ sed -i '/RestClient client = new RestClient/a \            client.CookieContaine
 sed -i '/private readonly string _baseUrl/a \        public readonly CookieContainer CookieContainer = new CookieContainer();\n' ./src/VRChat.API/Client/ApiClient.cs
 
 # Fix fields in csproj
-sed -i 's/OpenAPI Library/VRChat API Library for C# Core 5.0/' src/VRChat.API/VRChat.API.csproj
-sed -i 's/A library generated from a OpenAPI doc/VRChat API Library for C# Core 5.0/' src/VRChat.API/VRChat.API.csproj
+sed -i 's/OpenAPI Library/VRChat API Library for .NET/' src/VRChat.API/VRChat.API.csproj
+sed -i 's/A library generated from a OpenAPI doc/VRChat API Library for .NET/' src/VRChat.API/VRChat.API.csproj
 sed -i 's/No Copyright/Copyright © 2021 Owners of GitHub organisation "vrchatapi" and individual contributors./' src/VRChat.API/VRChat.API.csproj
 sed -i 's/OpenAPI/VRChat API Docs Community/' src/VRChat.API/VRChat.API.csproj
 sed -i 's/Minor update/Automated deployment/' src/VRChat.API/VRChat.API.csproj

--- a/src/VRChat.API/Client/ApiClient.cs
+++ b/src/VRChat.API/Client/ApiClient.cs
@@ -22,7 +22,6 @@ using System.Text;
 using System.Threading;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Web;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using ErrorEventArgs = Newtonsoft.Json.Serialization.ErrorEventArgs;

--- a/src/VRChat.API/Client/Configuration.cs
+++ b/src/VRChat.API/Client/Configuration.cs
@@ -56,11 +56,6 @@ namespace VRChat.API.Client
                     string.Format("Error calling {0}: {1}", methodName, response.RawContent),
                     response.RawContent, response.Headers);
             }
-            if (status == 0)
-            {
-                return new ApiException(status,
-                    string.Format("Error calling {0}: {1}", methodName, response.ErrorText), response.ErrorText);
-            }
             return null;
         };
 

--- a/src/VRChat.API/VRChat.API.csproj
+++ b/src/VRChat.API/VRChat.API.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>VRChat.API</AssemblyName>
     <PackageId>VRChat.API</PackageId>
     <OutputType>Library</OutputType>
     <Authors>VRChat API Docs Community</Authors>
     <Company>VRChat API Docs Community</Company>
-    <AssemblyTitle>VRChat API Library for C# Core 5.0</AssemblyTitle>
-    <Description>VRChat API Library for C# Core 5.0</Description>
+    <AssemblyTitle>VRChat API Library for .NET</AssemblyTitle>
+    <Description>VRChat API Library for .NET</Description>
     <Copyright>Copyright © 2021 Owners of GitHub organisation "vrchatapi" and individual contributors.</Copyright>
     <RootNamespace>VRChat.API</RootNamespace>
     <Version>1.6.1</Version>


### PR DESCRIPTION
The project is currently targeting `net5.0` also known as .NET 5 (not to be confused with the now deprecated .NET Core), however, .NET 5 is a framework, and this project can only be consumed by .NET 5-compatible projects (Framework, Core, Xamarin, UWP, MAUI, Mono, Unity, etc) are not supported.

The underlying libraries and toolings that this library uses all target .NET Standard 2.0, so it is safe to switch to .NET Standard 2.0 for this project.

I've also fixed the mistake of referring to .NET Core as C# core, as .NET can be consumed by VB/F#/C#/and C++ (or CLR).
