### PR TITLE
Add url encoding to username and password

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -37,6 +37,9 @@ for file in $(find ./src/VRChat.API -name '*.cs'); do
     sed -i 's/new Cookie(cookie.Name, cookie.Value)/new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)/g' $file
 done
 
+# Fix username and password encoding
+sed -i 's/VRChat.API.Client.ClientUtils.Base64Encode(this.Configuration.Username + \":\" + this.Configuration.Password)/VRChat.API.Client.ClientUtils.Base64Encode(System.Web.HttpUtility.UrlEncode(this.Configuration.Username) + ":" + System.Web.HttpUtility.UrlEncode(this.Configuration.Password))/g' src/VRChat.API/Api/AuthenticationApi.cs
+
 # Fix fields in csproj
 sed -i 's/OpenAPI Library/VRChat API Library for .NET/' src/VRChat.API/VRChat.API.csproj
 sed -i 's/A library generated from a OpenAPI doc/VRChat API Library for .NET/' src/VRChat.API/VRChat.API.csproj

--- a/src/VRChat.API/Api/AuthenticationApi.cs
+++ b/src/VRChat.API/Api/AuthenticationApi.cs
@@ -925,7 +925,7 @@ namespace VRChat.API.Api
             // http basic authentication required
             if (!string.IsNullOrEmpty(this.Configuration.Username) || !string.IsNullOrEmpty(this.Configuration.Password) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
             {
-                localVarRequestOptions.HeaderParameters.Add("Authorization", "Basic " + VRChat.API.Client.ClientUtils.Base64Encode(this.Configuration.Username + ":" + this.Configuration.Password));
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Basic " + VRChat.API.Client.ClientUtils.Base64Encode(System.Web.HttpUtility.UrlEncode(this.Configuration.Username) + ":" + System.Web.HttpUtility.UrlEncode(this.Configuration.Password)));
             }
             // authentication (twoFactorAuthCookie) required
             // cookie parameter support
@@ -1007,7 +1007,7 @@ namespace VRChat.API.Api
             // http basic authentication required
             if (!string.IsNullOrEmpty(this.Configuration.Username) || !string.IsNullOrEmpty(this.Configuration.Password) && !localVarRequestOptions.HeaderParameters.ContainsKey("Authorization"))
             {
-                localVarRequestOptions.HeaderParameters.Add("Authorization", "Basic " + VRChat.API.Client.ClientUtils.Base64Encode(this.Configuration.Username + ":" + this.Configuration.Password));
+                localVarRequestOptions.HeaderParameters.Add("Authorization", "Basic " + VRChat.API.Client.ClientUtils.Base64Encode(System.Web.HttpUtility.UrlEncode(this.Configuration.Username) + ":" + System.Web.HttpUtility.UrlEncode(this.Configuration.Password)));
             }
             // authentication (twoFactorAuthCookie) required
             // cookie parameter support


### PR DESCRIPTION
Havent tested it myself as I dont have unicode exclusive characters in my username and password, but accordig to https://discord.com/channels/418093857394262020/418512124529344523/1273334317191397518 and https://discord.com/channels/418093857394262020/418512124529344523/1270163691811115124 this should fix it