### PR TITLE
Avoid percent-encoding for "(" and ")" characters.

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -83,6 +83,9 @@ sed -i 's/IsRequired = true/IsRequired = false/g' src/VRChat.API/Model/CurrentUs
 # Add RequiresTwoFactorAuth property to CurrentUser
 sed -i '/public string UserIcon { get; set; }/a\\n        /// <summary>\n        /// An array of two-factor authentication methods available to use to with two factor authentication.\n        /// </summary>\n        [DataMember(Name = "requiresTwoFactorAuth", IsRequired = false, EmitDefaultValue = true)]\n        public List<string> RequiresTwoFactorAuth { get; set; }' src/VRChat.API/Model/CurrentUser.cs
 
+# Avoid percent-encoding for "(" and ")" characters in URI
+sed -i 's/Uri.EscapeDataString(\([\.a-zA-Z _]*\))\([^\.]\)/Uri.EscapeDataString(\1).Replace("%28", "(").Replace("%29", ")")\2/g' src/VRChat.API/Client/WebRequestPathBuilder.cs
+
 # Remove messily pasted markdown at top of every file
 for i in src/VRChat.API/*/*.cs; do
     sed -i '/VRChat API Banner/d' $i

--- a/src/VRChat.API/Client/WebRequestPathBuilder.cs
+++ b/src/VRChat.API/Client/WebRequestPathBuilder.cs
@@ -30,7 +30,7 @@ namespace VRChat.API.Client
             {
                 foreach (var parameter in parameters)
                 {
-                    _path = _path.Replace("{" + parameter.Key + "}", Uri.EscapeDataString(parameter.Value));
+                    _path = _path.Replace("{" + parameter.Key + "}", Uri.EscapeDataString(parameter.Value).Replace("%28", "(").Replace("%29", ")"));
                 }
             }
 
@@ -40,7 +40,7 @@ namespace VRChat.API.Client
                 {
                     foreach (var value in parameter.Value)
                     {
-                        _query = _query + parameter.Key + "=" + Uri.EscapeDataString(value) + "&";
+                        _query = _query + parameter.Key + "=" + Uri.EscapeDataString(value).Replace("%28", "(").Replace("%29", ")") + "&";
                     }
                 }
             }


### PR DESCRIPTION
The VRChat API does not accept percent-encoded variants of InstanceID, specifically the characters "(" and ")". This causes an error when attempting the following API call:
```
https://api.vrchat.cloud/api/1/instances/wrld_28aab3e4-953f-4c85-9223-ef29a0873a6e:31124%7Egroup%28grp_b2a19685-c53e-4c5a-9503-744a5373bf2c%29%7EgroupAccessType%28plus%29%7Eregion%28use%29/shortName
```
```json
{"error":{"message":"\"malformed url\"","status_code":400,"waf_code":26497}}
```

When using the raw string without encoding, the API yields a `200` response as expected.
```
https://vrchat.com/api/1/instances/wrld_28aab3e4-953f-4c85-9223-ef29a0873a6e:31124~group(grp_b2a19685-c53e-4c5a-9503-744a5373bf2c)~groupAccessType(plus)~region(use)/shortName
```

See https://github.com/vrchatapi/vrchatapi-rust/pull/43 for more details. 